### PR TITLE
Set verbatim and email input type for usernames

### DIFF
--- a/scripts/waalt/connectors/xmpp.js
+++ b/scripts/waalt/connectors/xmpp.js
@@ -286,7 +286,7 @@ App.logForms['XMPP'] = function (article, provider, data) {
     .append($('<h1/>').style('color', data.color).html(_('SettingUp', { provider: data.longName })))
     .append($('<img/>').attr('src', 'img/providers/' + provider + '.svg'))
     .append($('<label/>').attr('for', 'user').text(_(data.terms['user'], { provider: data.altname })))
-    .append($('<input/>').attr('type', 'text').attr('name', 'user').attr('placeholder', (data.terms.placeholder || _(data.terms['user'], { provider: data.altname }) )))
+    .append($('<input/>').attr('type', data.terms.userInputType).attr('x-inputmode', 'verbatim').attr('name', 'user').attr('placeholder', (data.terms.placeholder || _(data.terms['user'], { provider: data.altname }) )))
     .append($('<label/>').attr('for', 'pass').text(_(data.terms['pass'])))
     .append($('<input/>').attr('type', 'password').attr('name', 'pass').attr('placeholder', '******'));
   if (data.notice) {

--- a/scripts/waalt/providers.js
+++ b/scripts/waalt/providers.js
@@ -32,6 +32,7 @@ var Providers = {
       terms: {
         user: 'ProviderUsername',
         pass: 'Password',
+        userInputType: 'text'
       },
       notice: true,
       emoji: 'FB'
@@ -50,7 +51,8 @@ var Providers = {
       terms: {
         user: 'ProviderAddress',
         pass: 'Password',
-        placeholder: 'username@gmail.com'
+        placeholder: 'username@gmail.com',
+        userInputType: 'email'
       },
       notice: true,
       emoji: 'XMPP'
@@ -67,7 +69,8 @@ var Providers = {
       color: '#FF8702',
       terms: {
         user: 'Username',
-        pass: 'Password'
+        pass: 'Password',
+        userInputType: 'text'
       },
       emoji: 'XMPP'
     },
@@ -84,7 +87,8 @@ var Providers = {
       color: '#39B006',
       terms: {
         user: 'Username',
-        pass: 'Password'
+        pass: 'Password',
+        userInputType: 'text'
       },
       emoji: 'XMPP'
     },
@@ -102,7 +106,8 @@ var Providers = {
       terms: {
         user: 'ProviderAddress',
         pass: 'Password',
-        placeholder: 'username@example.com'
+        placeholder: 'username@example.com',
+        userInputType: 'email'
       },
       emoji: 'XMPP'
     },
@@ -119,7 +124,8 @@ var Providers = {
       terms: {
         user: 'FullJID',
         pass: 'Password',
-        placeholder: 'username@example.com'
+        placeholder: 'username@example.com',
+        userInputType: 'email'
       },
       emoji: 'XMPP'
     }


### PR DESCRIPTION
- Set input type email for username fields that ask for email during sign-in
- Set inputmode verbatim so that keyboard suggestions are disabled for username fields.
