### PR TITLE
Reconnect on socket error

### DIFF
--- a/scripts/loqui/connectors/coseme.js
+++ b/scripts/loqui/connectors/coseme.js
@@ -302,7 +302,16 @@ App.connectors['coseme'] = function (account) {
   }
   
   this.events.onDisconnected = function () {
-    this.account.connect();
+    if (App.online) {
+      this.connect({
+        connected: function () {
+          Tools.log('RECONNECTED');
+        },
+        authfail: function () {
+          Tools.log('FAILED TO RECONNECT');
+        }
+      });
+    }
   }
   
   this.events.onMessage = function (id, from, body, stamp, e, nick, g) {


### PR DESCRIPTION
EPIC: This fixes virtually every reported case of WhatsApp accounts constantly disconnecting.
This means that the reconnect button _should not_ be necessary any more...
