### PR TITLE
Fixes #197

### DIFF
--- a/scripts/loqui/chat.js
+++ b/scripts/loqui/chat.js
@@ -68,6 +68,7 @@ var Chat = function (core, account) {
           Tools.log('PUSHING', blockIndex, chunk);
           chat.core.chunks.push(blockIndex);
           storageIndex = [blockIndex, 0];
+          callback();
         } else {
           Tools.log('FITS');
           chunk.push(msg);


### PR DESCRIPTION
The callback was not being called when the last chunk was null or full, so the serial queue stopped processing incoming messages.
