### PR TITLE
Fixes multimedia issues and cleans code

### DIFF
--- a/scripts/loqui/chat.js
+++ b/scripts/loqui/chat.js
@@ -11,7 +11,8 @@ var Chat = function (core, account) {
   // Render last chunk of messages
   this.lastChunkRender = function () {
     var ul = $('section#chat ul#messages');
-    ul.empty().append('<li/>');
+    //ul.empty().append($('<li/>').addClass('chunk'));
+    ul.empty();
     var index = this.core.chunks.length - 1;
     if (index >= 0) {
       this.chunkRender(index);
@@ -68,7 +69,7 @@ var Chat = function (core, account) {
           Tools.log('PUSHING', blockIndex, chunk);
           chat.core.chunks.push(blockIndex);
           storageIndex = [blockIndex, 0];
-          callback();
+          callback(blockIndex);
         } else {
           Tools.log('FITS');
           chunk.push(msg);
@@ -91,7 +92,7 @@ var Chat = function (core, account) {
       if (delay) {
         chat.account.toSendQ(storageIndex);
       }
-      callback();
+      callback(blockIndex);
     }
   }.bind(this));
   


### PR DESCRIPTION
Si estabas dentro de una conversación y alguien te enviaba un mensaje multimedia, si lo descargabas, ocurría que nunca se llegaba a marcar como descargado y sólo se podía reproducir o visualizar una única vez.

Con este PR también quedan organizados los atributos `data-index` y `data-id` de los mensajes de una forma más eficiente y ordenada.
