### PR TITLE
Redirect when Whatsapp auth fails

### DIFF
--- a/scripts/loqui/connectors/coseme.js
+++ b/scripts/loqui/connectors/coseme.js
@@ -32,7 +32,6 @@ App.connectors['coseme'] = function (account) {
       Tools.log("AUTH FAIL");
       this.connected = false;
       callback.authfail();
-      Lungo.Router.section('providers');
       Lungo.Notification.error(_('AuthInvalid'), _('AuthInvalidNotice'), 'warning-sign', 8);
     }.bind(this));
     MI.call(method, params);


### PR DESCRIPTION
When you are disconnect for any reason (for example, you lost internet connection) Whatsapp could not auth the coseme.id file so it redirects to the providers section. This is not a correct behavior, this commit solve this.
