### PR TITLE
Fix for issue 214

### DIFF
--- a/scripts/loqui/connectors/coseme.js
+++ b/scripts/loqui/connectors/coseme.js
@@ -552,12 +552,15 @@ App.connectors['coseme'] = function (account) {
       var uploadUrl = url;
       var onSuccess = function (url) {
         thumbnailer(blob, 120, 120, function(thumb) {
-          MI.call(
+          var id = MI.call(
             method,
             [toJID, url, hash, '0', thumb.split(',').pop()]
           );
           self.addMediaMessageToChat(type, thumb, url, account.core.user, toJID, Math.floor((new Date).getTime() / 1000) + '-1');
           App.audio('sent');
+          var ext = url.split('.').pop();
+          var localUrl = App.pathFiles + Tools.localize(Tools.stamp(id)).replace(/[-:]/g, '') + url.split('/').pop().substring(0, 5).toUpperCase() + '.' + ext;
+          Store.SD.save(localUrl, blob);
         });
         Lungo.Notification.show('up-sign', _('Uploaded'), 1);
       };

--- a/scripts/loqui/store.js
+++ b/scripts/loqui/store.js
@@ -130,8 +130,34 @@ var Store = {
           }
         });
       }
+    },
+      
+    copy : function (from, to, onsuccess, onerror) {
+      if (this.card) {
+        var req = this.card.get(from);
+        req.onsuccess = function () {
+          Store.SD.save(to, this.result, onsuccess, onerror);
+        }
+        req.onerror = function () {
+          if (onerror) {
+            onerror(this.error);
+            Lungo.Notification.error(_('Error'), _('NoSDAccess'), 'cloud-download', 5);
+          }
+        }
+      } else {
+        Tools.log('DS IS NOT SUPPORTED');
+        Store.get('fakesdcard_' + from, function (value) {
+          if (value) {
+            Store.put('fakesdcard_' + to, value, onsuccess);
+          } else {
+            if (onerror) {
+              onerror();
+            }
+          }
+        });
+      }
     }
     
   }
-  
+      
 }


### PR DESCRIPTION
- Stores a copy of the sent file in the `/emmc/loqui/files` folder.
- Adds a copy function just in case we need it
