### PR TITLE
Use secure WebSockets with XMPP accounts

### DIFF
--- a/scripts/loqui/providers.js
+++ b/scripts/loqui/providers.js
@@ -115,7 +115,7 @@ var Providers = {
       longName: 'XMPP/Jabber',
       connector: {
         type: 'XMPP',
-        host: 'https://app.loqui.im/http-bind/',
+        host: 'wss://app.loqui.im/ws/',
         timeout: 300
       },
       autodomain: false,


### PR DESCRIPTION
Now that we use `dev` as main repository... let's have some fun!
