### PR TITLE
Revert the logic of the provider features support system

### DIFF
--- a/scripts/loqui/account.js
+++ b/scripts/loqui/account.js
@@ -101,11 +101,11 @@ var Account = function (core) {
     var index = Accounts.find(this.core.fullJid);
     $('aside#accounts .indicator').style('top', (6.25+4.5*index)+'rem').show();
     Lungo.Element.count('section#main header nav button[data-view-article="chats"]', this.unread);
-    var lacks = Providers.data[this.core.provider].lacks;
+    var features = Providers.data[this.core.provider].features;
     var meSection = $('section#me');
     var mainSection = $('section#main');
-    meSection.data('lacks', lacks.join(' '));
-    mainSection.data('lacks', lacks.join(' '));
+    meSection.data('features', features.join(' '));
+    mainSection.data('features', features.join(' '));
     meSection.find('#status input').val(this.connector.presence.status);
     meSection.find('#card .name').text(address == this.core.user ? '' : address);
     meSection.find('#card .user').text(this.core.user);
@@ -131,9 +131,7 @@ var Account = function (core) {
     this.chatsRender();
     this.contactsRender();
     this.presenceRender();
-    if (this.supports('vcard')) {
-      this.avatarsRender();
-    }
+    this.avatarsRender();
   }
   
   // Changes some styles based on presence and connection status
@@ -440,7 +438,7 @@ var Account = function (core) {
     
   // Check for feature support
   this.supports = function (feature) {
-    return !this.connector.provider.lacks || this.connector.provider.lacks.indexOf(feature) < 0;
+    return this.connector.provider.features.indexOf(feature) >= 0;
   }
   
   // Save to store

--- a/scripts/loqui/chat.js
+++ b/scripts/loqui/chat.js
@@ -113,7 +113,7 @@ var Chat = function (core, account) {
     var section = $('section#chat');
     var header = section.children('header');
     section.data('jid', this.core.jid);
-    section.data('lacks', $('section#main').data('lacks'));
+    section.data('features', $('section#main').data('features'));
     section.data('muc', this.core.muc || false);
     header.children('.title').html(App.emoji[Providers.data[this.account.core.provider].emoji].fy(this.core.title));
     if (this.core.muc) {

--- a/scripts/loqui/providers.js
+++ b/scripts/loqui/providers.js
@@ -9,7 +9,7 @@ var Providers = {
       connector: {
         type: 'coseme'
       },
-      lacks: ['attention', 'multi', 'presence', 'easyAvatars', 'avatarChange', 'statusChange'],
+      features: ['localContacts', 'receipts', 'imageSend', 'videoSend', 'audioSend', 'locationSend', 'pay', 'muc', 'csn'],
       color: '#254242',
       terms: {
         user: 'YourNumber',
@@ -27,7 +27,7 @@ var Providers = {
         timeout: 300
       },
       autodomain: 'chat.facebook.com',
-      lacks: ['multi', 'avatarChange', 'statusChange', 'attention', 'rosterMgmt', 'receipts', 'localContacts', 'imageSend', 'pay', 'videoSend', 'audioSend', 'locationSend'],
+      features: ['vcard', 'presence', 'easyAvatars', 'csn'],
       color: '#3D539F',
       terms: {
         user: 'ProviderUsername',
@@ -46,7 +46,7 @@ var Providers = {
         timeout: 300
       },
       autodomain: 'gmail.com',
-      lacks: ['avatarChange', 'receipts', 'localContacts', 'imageSend', 'pay', 'videoSend', 'audioSend', 'locationSend'],
+      features: ['multi', 'presence', 'vcard', 'easyAvatars', 'avatarChange', 'rosterMgmt', 'csn', 'delay'],
       color: '#4EA43B',
       terms: {
         user: 'ProviderAddress',
@@ -65,7 +65,7 @@ var Providers = {
         timeout: 300
       },
       autodomain: 'nimbuzz.com',
-      lacks: ['vcard', 'avatarChange', 'attention', 'receipts', 'localContacts', 'imageSend', 'pay', 'videoSend', 'audioSend', 'locationSend'],
+      features: ['multi', 'presence', 'easyAvatars', 'csn'],
       color: '#FF8702',
       terms: {
         user: 'Username',
@@ -83,7 +83,7 @@ var Providers = {
         timeout: 300
       },
       autodomain: 'chat.ovi.com',
-      lacks: ['avatarChange', 'attention', 'receipts', 'localContacts', 'imageSend', 'pay', 'videoSend', 'audioSend', 'locationSend'],
+      features: ['multi', 'presence', 'easyAvatars', 'csn'],
       color: '#39B006',
       terms: {
         user: 'Username',
@@ -101,7 +101,7 @@ var Providers = {
         timeout: 300
       },
       autodomain: false,
-      lacks: ['avatarChange', 'attention', 'receipts', 'localContacts', 'imageSend', 'pay', 'videoSend', 'audioSend', 'locationSend'],
+      features: ['multi', 'presence', 'easyAvatars', 'csn'],
       color: '#0071C5',
       terms: {
         user: 'ProviderAddress',
@@ -119,7 +119,7 @@ var Providers = {
         timeout: 300
       },
       autodomain: false,
-      lacks: ['receipts', 'localContacts', 'imageSend', 'pay', 'videoSend', 'audioSend', 'locationSend'],
+      features: ['multi', 'vcard', 'presence', 'easyAvatars', 'rosterMgmt', 'avatarChange', 'attention', 'csn', 'delay', 'time'],
       color: '#149ED2',
       terms: {
         user: 'FullJID',

--- a/style/loqui/index.css
+++ b/style/loqui/index.css
@@ -372,7 +372,7 @@ section#main fieldset#searchForm input {
   border-radius: .2rem!important;
   width: calc(100% - .5rem);
 }
-section#main:not([data-lacks~='localContacts']) fieldset#searchForm input {
+section#main[data-features~='localContacts'] fieldset#searchForm input {
   width: calc(100% - 2rem);
 }
 section#main fieldset#searchForm span.sync {
@@ -383,7 +383,7 @@ section#main fieldset#searchForm span.sync {
   right: 0;
   padding: .5rem .4rem .5rem .4rem;
 }
-section#main[data-lacks~='localContacts'] fieldset#searchForm span.sync {
+section#main:not([data-features~='localContacts']) fieldset#searchForm span.sync {
   display: none;
 }
 section#main fieldset#searchForm span.clear {
@@ -396,7 +396,7 @@ section#main fieldset#searchForm span.clear {
   color: #CCC;
   font-size: 1.4rem;
 }
-section#main:not([data-lacks~='localContacts']) fieldset#searchForm span.clear {
+section#main[data-features~='localContacts'] fieldset#searchForm span.clear {
   right: 1.8rem;
 }
 
@@ -755,7 +755,7 @@ section#chat article#videocall button {
   width: 100%;
 }
 
-section[data-lacks~=presence] span.show {
+section:not([data-features~=presence]) span.show {
   display: none!important;
 }
 
@@ -812,25 +812,25 @@ section.profile div#card span.provider img {
   height: 1rem;
   margin-right: .3rem;
 }
-section#me[data-lacks~=statusChange] div#status {
+section#me:not([data-features~=statusChange]) div#status {
   display: none!important;
 }
-section#me[data-lacks~=rosterMgmt] button.contactAdd {
+section#me:not([data-features~=rosterMgmt]) button.contactAdd {
   display: none!important;
 }
-section#me[data-lacks~=pay] button.accountPurchase {
+section#me:not([data-features~=pay]) button.accountPurchase {
   display: none!important;
 }
-section#chat[data-lacks~=imageSend] a.picture {
+section#chat:not([data-features~=imageSend]) a.picture {
   display: none!important;
 }
-section#chat[data-lacks~=videoSend] a.video {
+section#chat:not([data-features~=videoSend]) a.video {
   display: none!important;
 }
-section#chat[data-lacks~=audioSend] a.audio {
+section#chat:not([data-features~=audioSend]) a.audio {
   display: none!important;
 }
-section#chat[data-lacks~=locationSend] a.location {
+section#chat:not([data-features~=locationSend]) a.location {
   display: none!important;
 }
 section#me div#status input {


### PR DESCRIPTION
This PR reverts the logic of the provider features support system.

The API remains the same: `Messenger.account().supports('feature');`
