### PR TITLE
fixes: reference error with provider longName used in the alt attribute ...

### DIFF
--- a/scripts/loqui/providers.js
+++ b/scripts/loqui/providers.js
@@ -130,7 +130,7 @@ var Providers = {
       emoji: 'XMPP'
     }
   },
-  
+
   // Dinamically prints the provider list
   list: function () {
     var ul = $('section#providers ul');
@@ -140,7 +140,7 @@ var Providers = {
       var a = $('<a/>').data('view-section', provider);
       a.text(data.longName);
       var img = $('<img/>').attr('src', 'img/providers/' + provider + '.svg');
-      img.attr('alt', longName);
+      img.attr('alt', data.longName);
       a.prepend(img);
       li.append(a);
       ul.append(li);
@@ -151,7 +151,7 @@ var Providers = {
       $('body').append(section);
     }
   },
-  
+
   // Autocompletes adresses with default domain names
   autoComplete: function (user, provider) {
     var bits = user.split('@');


### PR DESCRIPTION
This basically a fix for a typo in the providers source code. There is an img tag that is supposed to receive the provider long name in its alt attribute but the variable has a typo in it. It reads "longName" instead of "data.longName" silly thing but such an easy fix and it is one less error on the console.
