### PR TITLE
#85 unfocus keyboard on sending text disabled

### DIFF
--- a/scripts/loqui/bindings.js
+++ b/scripts/loqui/bindings.js
@@ -188,8 +188,11 @@ var bindings = function () {
   $('section#contactAdd button.add').on('click', function() {
     Messenger.contactAdd();
   });
-  $('section#chat #footbox #say').on('click', function() {
+  $('section#chat #footbox #say').on('click', function(e) {
     Messenger.say();
+  }).on('mousedown', function(e){
+    e.preventDefault();
+    e.target.classList.add('active');
   });
   $('section#chat nav#plus a.cancel').on('click', function() {
     $(this).parent().removeClass('show');


### PR DESCRIPTION
Now the keyboards is always visible when we click on say button (#85).
I use this to prevent that behaviour: 
https://github.com/mozilla-b2g/gaia/blob/1e66ee35c4fb1aa46c615241d91711e6121662b9/apps/sms/js/sms.js#L820

its tricky, but works :tongue: 
