### PR TITLE
add a pulse for whatsapp accounts #359

### DIFF
--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -18,6 +18,18 @@ var Account = function (core) {
     $.extend(this.OTR, App.defaults.Account.core.OTR);
   }
   
+  if(this.connector.presence.get){
+    var account= this;
+    setInterval(function(){
+      if(account.connector.isConnected()){
+	console.log('keep alive!');
+	account.chats.forEach(function(chat){
+	  account.connector.presence.get(chat.core.jid);
+	});
+      }
+    }, 30000);
+  }
+
   // Test account
   this.test = function () {
     this.connector.connect({

--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -19,15 +19,16 @@ var Account = function (core) {
   }
   
   if(this.connector.presence.get){
-    var account= this;
-    setInterval(function(){
-      if(account.connector.isConnected()){
-	console.log('keep alive!');
-	account.chats.forEach(function(chat){
-	  account.connector.presence.get(chat.core.jid);
-	});
-      }
-    }, 30000);
+      var account= this;
+      setInterval(function(){
+          if(account.core.enabled){
+              console.log('keep alive!');
+              account.chats.forEach(function(chat){
+                  if(!chat.core.muc)
+                      account.connector.presence.get(chat.core.jid);
+              });
+          }
+      }, 30000);
   }
 
   // Test account

--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -18,7 +18,7 @@ var Account = function (core) {
     $.extend(this.OTR, App.defaults.Account.core.OTR);
   }
   
-  if(this.connector.presence.get){
+  if(this.connector.sync){
       var account= this;
       setInterval(function(){
           if(account.core.enabled){
@@ -26,10 +26,6 @@ var Account = function (core) {
               account.sync(function(sync){
                   sync();
               });
-//              account.chats.forEach(function(chat){
-//                  if(!chat.core.muc)
-//                      account.connector.presence.get(chat.core.jid);
-//              });
           }
       }, 30000);
   }

--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -23,10 +23,13 @@ var Account = function (core) {
       setInterval(function(){
           if(account.core.enabled){
               console.log('keep alive!');
-              account.chats.forEach(function(chat){
-                  if(!chat.core.muc)
-                      account.connector.presence.get(chat.core.jid);
+              account.sync(function(sync){
+                  sync();
               });
+//              account.chats.forEach(function(chat){
+//                  if(!chat.core.muc)
+//                      account.connector.presence.get(chat.core.jid);
+//              });
           }
       }, 30000);
   }


### PR DESCRIPTION
This adds an interval that sends presence requests for every chat every 30 seconds to keep the connection to whatsapp alive.
I tested it on my Geeksphone Peak and I can say that I wasn't disconnected the entire day. I was most of the time on wifi and the battery usage didn't increased, but I'll do future tests on mobile data, just to make sure.
