### PR TITLE
WhatsApp pulse rate limit hot fix

### DIFF
--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -27,7 +27,7 @@ var Account = function (core) {
           if(account.core.enabled){
               console.log('keep alive!');
               account.sync(function(sync){
-                  sync();
+                  sync(true);
               });
           }
       }, 30000);

--- a/src/scripts/loqui/connectors/coseme.js
+++ b/src/scripts/loqui/connectors/coseme.js
@@ -64,9 +64,11 @@ App.connectors['coseme'] = function (account) {
   }
   
   this.sync = function (callback) {
-    var getStatusesAndPics = function () {
-      var contacts = this.account.core.chats.map(function(e){return e.jid;});
-      MI.call('contacts_getStatus', [contacts]);
+    var getStatusesAndPics = function (noStatuses) {
+      if(!noStatuses){
+        var contacts = this.account.core.chats.map(function(e){return e.jid;});
+        MI.call('contacts_getStatus', [contacts]);
+      }
       this.avatar(null, [contacts]);
     }.bind(this);
     if (!('roster' in this.account.core) || !this.account.core.roster.length) {


### PR DESCRIPTION
I had to discover that WhatsApp quickly starts to block the status request overflow with an error message. The server only responses with the requested data again, when we stop our request for some time.
Because of this, I disabled the request of the statuses and the pulse will now just ask for the pictures. WhatsApp does not block these requests.
