### PR TITLE
fixes #563

### DIFF
--- a/src/scripts/loqui/connectors/coseme.js
+++ b/src/scripts/loqui/connectors/coseme.js
@@ -493,6 +493,32 @@ App.connectors['coseme'] = function (account) {
   
   this.events.onMessageSent = function (from, msgId) {
     Tools.log('SENT', from, msgId);
+    var chat= account.chatGet(from);
+    var lastIndex= chat.core.chunks[chat.core.chunks.length-1];
+    var secondLastIndex= chat.core.chunks[chat.core.chunks.length];
+
+    Store.recover(lastIndex, function(chunk){
+      for(var i in chunk){
+        var msg= chunk[i];
+        if(msg.id == msgId){
+          msg.status= 'sent';
+          msg= new Message(account, msg);
+          Store.update(lastIndex, chunk, msg.reRender.bind(msg, [lastIndex]));
+          return;
+        }
+      }
+      Store.recover(secondLastIndex, function(chunk){
+        for(var i in chunk){
+          var msg= chunk[i];
+          if(msg.id == msgId){
+            msg.status= 'sent';
+            msg= new Message(account, msg);
+            Store.update(secondLastIndex, chunk, msg.reRender.bind(msg, [secondLastIndex]));
+            return;
+          }
+        }
+      });
+    });
   }
 
   this.events.onMessageDelivered = function (from, msgId) {

--- a/src/scripts/loqui/messenger.js
+++ b/src/scripts/loqui/messenger.js
@@ -24,7 +24,8 @@ var Messenger = {
         from: account.core.user,
         to: to,
         text: text,
-        stamp: Tools.localize(Tools.stamp())
+        stamp: Tools.localize(Tools.stamp()),
+        status : 'sending'
       },
       {
         muc: muc

--- a/src/style/loqui/index.css
+++ b/src/style/loqui/index.css
@@ -832,6 +832,15 @@ section#chat ul#messages > li > div[data-type='out'] > span.text {
   background-color: #E95644;
   color: white;
 }
+section#chat ul#messages > li > div[data-type='out'][data-status='sending'] > span.text {
+  background-color: #efcc12;
+}
+section#chat ul#messages > li > div[data-type='out'][data-status='failed'] > span.text {
+  background-color: #EEE;
+  color: #000 !important;
+  padding: calc(0.5rem - 2px) calc(0.6rem - 2px) !important;
+  border: 2px solid #E95644;
+}
 section#chat ul#messages > li > div[data-type='in'] > span.text {
   left: 1.8rem;
   background-color: #EEE;


### PR DESCRIPTION
This implements an message sent indicator:
- yellow message -> trying to send the message
- red (default color) -> message successfully sent
- gray with red border -> failed to send the message

Note: If the message gets successfully sent but Loqui disconnects right after that and does not recive the sent ACK from WhatsApp, then the message still gets marked as failed. Eventually the message changes to send when Loqui reconnects and receives the ACK.
