### PR TITLE
save new presence status

### DIFF
--- a/src/scripts/loqui/bindings.js
+++ b/src/scripts/loqui/bindings.js
@@ -60,10 +60,10 @@ document.addEventListener("visibilitychange", function() {
   for (var i in App.accounts) {
     var account = App.accounts[i];
     if (document.hidden) {
-      account.connector.presence.send('away');
+      account.connector.presence.set('away');
     } else {
       App.lastActive = new Date;
-      account.connector.presence.send();
+      account.connector.presence.set('a');
 
       var section = $('section#chat');
       if(section.hasClass('show')){


### PR DESCRIPTION
don't just send the new presence status, also save it. Otherwise the app gets restaret in the background and the accounts presence will be set to available.
