### PR TITLE
quick fix

### DIFF
--- a/src/scripts/loqui/message.js
+++ b/src/scripts/loqui/message.js
@@ -154,7 +154,6 @@ var Message = function (account, core, options) {
       } else {
         chat.unread++;
         chat.core.unread++;
-        account.unread++;
       }
     });
   };


### PR DESCRIPTION
since the setter was removed this causes messages to get swallowed.
