### PR TITLE
messages markqueue fix

### DIFF
--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -634,6 +634,9 @@ var Account = function (core) {
       msg = new Message(account, msg);
       Store.update(result.chunkIndex, result.chunk, callback);
       msg.reRender(result.chunkIndex);
+    }, function(e){
+        Tools.log('UNABLE TO FIND MESSAGE! CARRY ON', from, msgId, e);
+        callback();
     });
   }.bind(this));
 

--- a/src/scripts/loqui/chat.js
+++ b/src/scripts/loqui/chat.js
@@ -289,18 +289,22 @@ var Chat = function (core, account) {
       var found= false;
       var checkChunk= function(chunk, chunkIndex){
         var result= null;
-        chunk.forEach(function(item, i){
-          if(item.id == msgId){
-            found= true;
-            result= {
-              index : i,
-              chunk : chunk,
-              chunkIndex : chat.chunks[chunkIndex],
-              message : item
-            };
-          }
-        });
-        return result;
+        if(chunk){
+          chunk.forEach(function(item, i){
+            if(item.id == msgId){
+              found= true;
+              result= {
+                index : i,
+                chunk : chunk,
+                chunkIndex : chat.chunks[chunkIndex],
+                message : item
+              };
+            }
+          });
+          return result;
+        }else{
+          return null;
+        }
       };
       if(chunkIndex || chunkIndex === 0){
         Store.recover(chunkIndex, function(chunk){


### PR DESCRIPTION
sometimes the messages markqueue stops because we can't find a message. I'm still not sure why some messages can not be found, but this prevents the queue from stopping.
