### PR TITLE
Improvements for landscape mode (fixes #687)

### DIFF
--- a/src/scripts/loqui/bindings.js
+++ b/src/scripts/loqui/bindings.js
@@ -124,17 +124,32 @@ $('section#chat article#main div#text').on('keydown', function (e) {
       $('section#chat nav#plus').removeClass('show');
       Messenger.csn('paused');
     }
+    // if user wants to hide keyboard in landscape
+    // user can clear the box and press backspace to hide it
+    if (this.textContent.length === 0 && e.which == 8 && window.matchMedia('(orientation:landscape)').matches) {
+      $('section#chat article#main div#text').blur();
+    }
   } else {
     $('section#chat article#main button#plus').hide();
     $('section#chat article#main button#say').show();
-    $('section#chat nav#plus').addClass('show');
+    // only show plus bar when in portrait mode
+    if (window.matchMedia('(orientation:portrait)').matches) {
+      $('section#chat nav#plus').addClass('show');
+    } else {
+      $('section#chat nav#plus').removeClass('show');
+    }
     var ul = $('section#chat ul#messages');
     ul[0].scrollTop = ul[0].scrollHeight;
     Messenger.csn('composing');
   }
 }).on('tap', function (e) {
   Lungo.Router.article('chat', 'main');
-  $('section#chat nav#plus').addClass('show');
+  // only show plus bar when in portrait mode
+  if (window.matchMedia('(orientation:portrait)').matches) {
+    $('section#chat nav#plus').addClass('show');
+  } else {
+    $('section#chat nav#plus').removeClass('show');
+  }
   var ul = $('section#chat ul#messages');
   ul[0].scrollTop = ul[0].scrollHeight + 500;
 }).on('blur', function (e) {

--- a/src/style/loqui/index.css
+++ b/src/style/loqui/index.css
@@ -1630,7 +1630,9 @@ article.form ul.listBox li.add:before {
   }
 }
 
-/* MEDIA QUERIES */
+/* MEDIA QUERIES
+ * this query improves the text input in landscape mode
+ * when the keyboard is open */
 @media only screen and (orientation:landscape) and (max-height: 18vw) {
   #chat header {
     display: none;
@@ -1641,6 +1643,7 @@ article.form ul.listBox li.add:before {
   #messages {
     display: none;
   }
+  /* display footbox and text across the whole rest of the screen */
   #footbox {
     position: fixed;
     top: 0;
@@ -1654,18 +1657,25 @@ article.form ul.listBox li.add:before {
     bottom: 0;
     border: none;
     border-radius: 0;
+    z-index: 2;
   }
+  /* adjust the typing notification
+   * to be on the bottom of the text area */
   section#chat #footbox #typing {
     position: fixed;
-    z-index: 9;
+    z-index: 3;
     bottom: 0.1rem;
     top: auto;
   }
+  /* display buttons on top of the text field */
   button {
-    z-index: 9;
+    z-index: 3;
   }
+  /* hide the plus bar completely in this mode */
   section#chat nav#plus {
     display: none;
+    visibility: hidden;
+    z-index: -2;
   }
 }
 

--- a/src/style/loqui/index.css
+++ b/src/style/loqui/index.css
@@ -1641,6 +1641,10 @@ article.form ul.listBox li.add:before {
   #messages {
     display: none;
   }
+  #footbox {
+    position: fixed;
+    top: 0;
+  }
   #text {
     position: fixed;
     top: 0;
@@ -1650,6 +1654,18 @@ article.form ul.listBox li.add:before {
     bottom: 0;
     border: none;
     border-radius: 0;
+  }
+  section#chat #footbox #typing {
+    position: fixed;
+    z-index: 9;
+    bottom: 0.1rem;
+    top: auto;
+  }
+  button {
+    z-index: 9;
+  }
+  section#chat nav#plus {
+    display: none;
   }
 }
 


### PR DESCRIPTION
This provides some fixes for the landscape mode:
- the plus bar is now hidden when typing in landscape
- footbox stretches across the whole screen (visual improvement mainly)
- typing notification works again

This should fix issue #687
