### PR TITLE
initial message from a new contact not shown in preview and doesn't trigger a notification

### DIFF
--- a/src/scripts/loqui/chat.js
+++ b/src/scripts/loqui/chat.js
@@ -175,6 +175,7 @@ var Chat = function (core, account) {
       Tools.log('PUSHING', blockIndex, chunk);
       chat.core.chunks.push(blockIndex);
       storageIndex = [blockIndex, 0];
+      chat.core.last = msg;
       if (delay) {
         chat.account.toSendQ(storageIndex);
       }


### PR DESCRIPTION
fixing breakage from commit 2857d13a856cd13e28cd40c86bf6f819b9c8f574 for issue #532 as chat.core.last is not set any more in "NEW" branch.
