### PR TITLE
keep track of last seen time for all contacts, not just active chats

### DIFF
--- a/src/scripts/loqui/chat.js
+++ b/src/scripts/loqui/chat.js
@@ -292,15 +292,13 @@ var Chat = function (core, account) {
             header.children('.status').text(' ');
           }
         } else {
-          var show = contact ? (contact.presence.show || 'na') : 'na';
-          var status = contact ? (contact.presence.status || _('show' + show)) : ' ';
-          if (this.account.connector.presence.subscribe) {
+          if (contact && this.account.connector.presence.subscribe) {
             this.account.connector.presence.subscribe(this.core.jid);
           }
-          header.children('.status').html(App.emoji[Providers.data[this.account.core.provider].emoji].fy(status));
-          if (this.account.supports('show')) {
-            section[0].dataset.show = show;
+          if (contact && this.account.connector.contacts.getStatus && (contact.presence.status === null)) {
+            this.account.connector.contacts.getStatus([this.core.jid]);
           }
+          this.account.presenceRender(this.core.jid);
         }
         this.lastChunkRender();
         this.unreadList= [];

--- a/src/scripts/loqui/connectors/coseme.js
+++ b/src/scripts/loqui/connectors/coseme.js
@@ -106,6 +106,9 @@ App.connectors.coseme = function (account) {
     }
   }.bind(this);
   
+  this.contacts.getStatus = function (jids) {
+    MI.call('contacts_getStatus', [jids]);
+  }.bind(this);
   
   this.contacts.sync = function (cb) {
     if (App.online) {
@@ -378,7 +381,7 @@ App.connectors.coseme = function (account) {
       notification_groupParticipantRemoved: this.events.onGroupParticipantRemoved,
       notification_groupCreated: this.events.onGroupCreated,
       notification_groupSubjectUpdated: this.events.onGroupSubjectUpdated,
-      notification_status: this.events.onNotification,
+      notification_status: this.events.onContactStatusUpdated,
       contact_gotProfilePictureId: this.events.onAvatar,
       contact_gotProfilePicture: this.events.onAvatar,
       contact_typing: this.events.onContactTyping,
@@ -410,7 +413,9 @@ App.connectors.coseme = function (account) {
     MI.call(method, [categories]);
   };
   
-  this.events.onNotification = function (jid, msgId) {
+  this.events.onContactStatusUpdated = function (jid, msgId, status) {
+    this.events.onPresenceUpdated(jid, undefined, status);
+
     var method = 'notification_ack';
     MI.call(method, [jid, msgId]);
   };
@@ -831,7 +836,8 @@ App.connectors.coseme = function (account) {
     if (contact) {
       Tools.log('PRESENCE for', jid, 'WAS', contact.presence.show, 'NOW IS', 'away');
       contact.presence.show = 'away';
-      account.presenceRender(jid, last);
+      contact.presence.last = last;
+      account.presenceRender(jid);
     }
   };
   

--- a/src/scripts/mozillahispano/coseme.js
+++ b/src/scripts/mozillahispano/coseme.js
@@ -6824,7 +6824,9 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
                                  author]);
         }
         else if (type === 'status') {
-          _signalInterface.send('notification_status', [from, msgId]);
+          var bodyNode = node.getChild(0);
+          var status = stringFromUtf8(bodyNode.data);
+          _signalInterface.send('notification_status', [from, msgId, status]);
         }
         else {
           // ignore, but at least acknowledge it


### PR DESCRIPTION
process status update notifications
render status and last seen time in a single place
reduce number of unnecessary re-rendering when setting current account
