### PR TITLE
don't delete the roster when triggering a sync

### DIFF
--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -315,7 +315,6 @@ var Account = function (core) {
       }));
     if (account.supports('localContacts')) {
       header.append($('<button/>').addClass('sync').text(_('ContactsSync')).on('click', function (event) {
-        delete account.core.roster;
         account.connector.contacts.sync(function (rcb) {
           account.save();
           Lungo.Router.section('main');


### PR DESCRIPTION
as this screws it up when the sync fails (it gets replaced anyway when
the sync finishes)
