### PR TITLE
Insert a wake lock shim

### DIFF
--- a/src/scripts/loqui/bindings.js
+++ b/src/scripts/loqui/bindings.js
@@ -31,6 +31,14 @@ $('document').ready(function(){
 
     App.defaults.Selects.language[0] = { caption : _('Default'), value : 'default' };
 
+
+//  wakelock shim
+    navigator.requestWakeLock = navigator.requestWakeLock || function(){
+      return {
+        unlock : function(){}
+      };
+    };
+
     bindings();
     App.run();
   });


### PR DESCRIPTION
to prevent loqui from breaking on Android and Desktop.
