### PR TITLE
wait until other client requests subscription

### DIFF
--- a/src/scripts/loqui/messenger.js
+++ b/src/scripts/loqui/messenger.js
@@ -256,7 +256,15 @@ var Messenger = {
         if (jid && name) {
           account.connector.connection.roster.add(jid, name, false, false);
           account.connector.connection.roster.subscribe(jid);
-          account.connector.connection.roster.authorize(jid);
+
+          account.connector.connection.roster.registerCallback(function cb(items, item){
+            console.log(item);
+            if (item && item.ask == 'subscribe') {
+              account.connector.connection.roster.authorize(jid);
+              account.connector.connection.roster.unregisterCallback(cb);
+            }
+          });
+
           section.find('input').val('');
           account.core.roster.push({
             jid: jid,

--- a/src/scripts/strophe/plugins/roster.js
+++ b/src/scripts/strophe/plugins/roster.js
@@ -143,6 +143,11 @@ Strophe.addConnectionPlugin('roster',
     {
         this._callbacks.push(call_back);
     },
+
+    unregisterCallback: function(call_back)
+    {
+        this._callbacks.splice(this._callbacks.indexOf(callback), 1);
+    },
     /** Function: clearCallbacks
      * clear all callbacks on roster
      */


### PR DESCRIPTION
Tested with Adium. We need to wait until the client requests the authorization, otherwise the contact won't process it and can't see us.
