### PR TITLE
Revert "Fix authorization for Loqui"

### DIFF
--- a/src/scripts/loqui/messenger.js
+++ b/src/scripts/loqui/messenger.js
@@ -258,14 +258,12 @@ var Messenger = {
           account.connector.connection.roster.subscribe(jid);
 
           account.connector.connection.roster.registerCallback(function cb(items, item){
-//            console.log(item);
-            if (item && item.ask == 'subscribe' && item.jid == 'jid') {
+            console.log(item);
+            if (item && item.ask == 'subscribe') {
               account.connector.connection.roster.authorize(jid);
               account.connector.connection.roster.unregisterCallback(cb);
             }
           });
-
-          account.connector.connection.roster.authorize(jid);
 
           section.find('input').val('');
           account.core.roster.push({

--- a/src/scripts/strophe/plugins/roster.js
+++ b/src/scripts/strophe/plugins/roster.js
@@ -146,7 +146,7 @@ Strophe.addConnectionPlugin('roster',
 
     unregisterCallback: function(call_back)
     {
-        this._callbacks.splice(this._callbacks.indexOf(call_back), 1);
+        this._callbacks.splice(this._callbacks.indexOf(callback), 1);
     },
     /** Function: clearCallbacks
      * clear all callbacks on roster


### PR DESCRIPTION
Reverts loqui/im#836
The current code doesn't do any useful work because of the "&& item.jid == 'jid'" condition in the "if".
I really think this needs to be properly investigated - neither the XMPP spec nor tests with Gossip or pidgin show any issues with the original code (if there is an issue with Adium, a link to an Adium bug report would be helpful).
