### PR TITLE
Revert "wait until other client requests subscription"

### DIFF
--- a/src/scripts/loqui/messenger.js
+++ b/src/scripts/loqui/messenger.js
@@ -256,15 +256,7 @@ var Messenger = {
         if (jid && name) {
           account.connector.connection.roster.add(jid, name, false, false);
           account.connector.connection.roster.subscribe(jid);
-
-          account.connector.connection.roster.registerCallback(function cb(items, item){
-            console.log(item);
-            if (item && item.ask == 'subscribe') {
-              account.connector.connection.roster.authorize(jid);
-              account.connector.connection.roster.unregisterCallback(cb);
-            }
-          });
-
+          account.connector.connection.roster.authorize(jid);
           section.find('input').val('');
           account.core.roster.push({
             jid: jid,

--- a/src/scripts/strophe/plugins/roster.js
+++ b/src/scripts/strophe/plugins/roster.js
@@ -143,11 +143,6 @@ Strophe.addConnectionPlugin('roster',
     {
         this._callbacks.push(call_back);
     },
-
-    unregisterCallback: function(call_back)
-    {
-        this._callbacks.splice(this._callbacks.indexOf(callback), 1);
-    },
     /** Function: clearCallbacks
      * clear all callbacks on roster
      */


### PR DESCRIPTION
Reverts loqui/im#835
As mentioned in the other "revert PR", I really think this needs to be properly investigated - neither the XMPP spec nor tests with Gossip or pidgin show any issues with the original code (if there is an issue with Adium, a link to an Adium bug report would be helpful).
Also, this code does not do what the description suggests: ask=='subscribe' is not triggered by the remote client requesting authorization, but by the local client requesting authorization.
