### PR TITLE
Fix for inviting partecipants to a new group

### DIFF
--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -351,7 +351,9 @@ var Account = function (core) {
       }
       var li = document.createElement('li');
       li.dataset.jid = contact.jid;
-      if (selected && selected.indexOf(contact.jid) > -1) {
+      if (selected && Object.keys(selected).map(function (key) {
+        return selected[key];
+      }).indexOf(contact.jid) > -1) {
         li.classList.add('selected');
       }
       li.innerHTML =

--- a/src/scripts/loqui/menu.js
+++ b/src/scripts/loqui/menu.js
@@ -184,6 +184,11 @@ var Menu = {
         groups: false,
         selected: listBox && listBox.children().map(function (i,e,a) {return e.dataset.jid;})
       };
+      $('#mucCreateForm').removeClass('show');
+      $('#activity').find('button.remove').click(function () {
+        $('#mucCreateForm').addClass('show');
+        $('#activity').find('button.remove').off("click");
+      });
       Activity('invite', account, cb, options);
     },
     mucDirectInvite: function (obj) {

--- a/src/style/loqui/index.scss
+++ b/src/style/loqui/index.scss
@@ -346,7 +346,7 @@ section nav {
 }
 
 #activity {
-    z-index: 52 !important;
+    z-index: 52;
 
     li {
         :active {

--- a/src/style/loqui/index.scss
+++ b/src/style/loqui/index.scss
@@ -346,7 +346,7 @@ section nav {
 }
 
 #activity {
-    z-index: 52;
+    z-index: 52 !important;
 
     li {
         :active {


### PR DESCRIPTION
Right now I'm not able to invite partecipants to a new WA group, because the selection of partecipants remain hidden behind the 'create group' screen, and because of a small error in loqui/account.js.
This PR should fix these problem.

Best regards
Daniele 
