### PR TITLE
fix breaking of media rendering

### DIFF
--- a/src/scripts/loqui/message.js
+++ b/src/scripts/loqui/message.js
@@ -376,7 +376,7 @@ var Message = {
     var html= null;
     var onDivClick= null;
     if (this.core.text) {
-      html = App.emoji[Providers.data[this.account.core.provider].emoji].fy(Tools.urlHL(Tools.HTMLescape(this.core.text)));
+      html = App.emoji[Providers.data[this.account.core.provider].emoji].fy(Tools.urlHL(Tools.HTMLescape(this.core.text))).replace(/<br>/gi,"");
     } else if (this.core.media) {
       html = $('<img/>').attr('src', this.core.media.thumb);
       html[0].dataset.url = this.core.media.url;
@@ -502,7 +502,7 @@ var Message = {
     }
 
     if (html) {
-      var textSpan = $('<span/>').addClass('text').html(html.replace(/<br>/gi,""));
+      var textSpan = $('<span/>').addClass('text').html(html);
       div.append(textSpan);
     }
 


### PR DESCRIPTION
This fixes the display of media messages.
Media messages are image objects and thus do not have a replace method.
The replace ist now applied on message creation time only on text messages.
