### PR TITLE
Better build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type": "AGPL"
   },
   "scripts": {
+    "build": "grunt",
     "jshint": "node_modules/jshint/bin/jshint -c .jshintrc --exclude-path .gitignore src/scripts/loqui",
     "jsdoc-init": "git clone -b gh-pages --single-branch https://github.com/loqui/im.git gh-pages",
     "jsdoc-build" : "sh jsdoc/build.sh",
@@ -24,6 +25,7 @@
   ],
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-compress": "~0.13.0",
     "grunt-contrib-connect": "~0.11.2",


### PR DESCRIPTION
eliminate the global grunt

just: `npm run build`
