### PR TITLE
fix: misplaced [0]

### DIFF
--- a/src/scripts/loqui/connectors/xmpp.js
+++ b/src/scripts/loqui/connectors/xmpp.js
@@ -651,7 +651,7 @@ App.logForms.XMPP = function (provider, article) {
       }
     },
     events: function (target) {
-      var article = target[0].closest('article');
+      var article = target.closest('article')[0];
       var provider = article.parentNode.id;
       var user = Providers.autoComplete($(article).children('[name="user"]').val(), provider);
 


### PR DESCRIPTION
Caused a JS error when creating xmpp account : "no function closest() on object". 
Patch test on simulator v2.1
