### PR TITLE
format-issues

### DIFF
--- a/src/style/loqui/index.scss
+++ b/src/style/loqui/index.scss
@@ -1315,8 +1315,8 @@ section nav {
         padding: .5rem 0;
         border-bottom: .1rem solid #E95644;
 
-        :before,
-        :after {
+        &:before,
+        &:after {
             content: '↓';
             margin: 0 .5rem;
             font-style: normal;
@@ -1705,6 +1705,7 @@ input[type='password'] {
         font-size: 1.4rem;
         margin: .5rem 0 2rem;
         color: $primary-text-color;
+        word-wrap: break-word;
     }
 
     .buttongroup {


### PR DESCRIPTION
fix two format issues
- the down arrows of the lastRead Marker did not show
- overlong status words caused the status window to scroll sideways, now they wrap
