### PR TITLE
fix-1024

### DIFF
--- a/src/scripts/loqui/message.js
+++ b/src/scripts/loqui/message.js
@@ -261,7 +261,6 @@ var Message = {
           account.avatarsRender();
         }
         $('section#chat #typing').hide();
-		    ul[0].scrollTop = ul[0].scrollHeight;
         chat.core.lastRead = Tools.localize(Tools.stamp());
         if (!$('section#chat').hasClass('show')) {
           chat.unread++;
@@ -270,6 +269,10 @@ var Message = {
         }else if(document.hidden){
           chat.unreadList.push(message);
         }else{
+          $('section#chat span.title').addClass('new-message');
+          setTimeout(function() {
+            $('section#chat span.title').removeClass('new-message');
+          }, 2000);
           message.read();
         }
       } else {

--- a/src/style/loqui/index.scss
+++ b/src/style/loqui/index.scss
@@ -743,6 +743,17 @@ section nav {
             display: block;
         }
 
+        .new-message:before {
+            font-family: 'Material Icons';
+            content: "message";
+            color: yellow;
+            font-size: 1.6rem;
+            height: 1.1em;
+            letter-spacing: normal;
+            vertical-align: middle;
+            padding-right: 1em;
+        }
+        
         .show {
             position: absolute;
             right: 5rem;


### PR DESCRIPTION
This fixed loqui/im#1024
If a new message arrives in the currently active chat, a yellow symbol is displayed in the title for 2 seconds.
Also one missing commit for issue #1026 is included that prevents the chat from scrolling when a new message arrives.
