### PR TITLE
Changed npm dependency from grunt-node-webkit-builder to grunt-nw-bui…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-contrib-copy": "~0.8.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-execute": "~0.2.2",
-    "grunt-node-webkit-builder": "~1.0.2",
+    "grunt-nw-builder": "~1.0.2",
     "grunt-sass": "^1.0.0",
     "grunt-sed": "^0.1.1",
     "ink-docstrap": "git://github.com/TitanNano/docstrap.git",


### PR DESCRIPTION
During `npm install` I got

> npm WARN deprecated grunt-node-webkit-builder@1.0.2: WARNING: This module has been renamed to grunt-nw-builder. Install using grunt-nw-builder instead, grunt-node-webkit-builder will no longer be updated.

So I thought it maybe helpful to create a PR for this ;-)
