### PR TITLE
add-decrypt-error-msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/scripts/loqui/blaze/renderers.js
 /src/nbproject/private/
 src/nbproject/project.properties
 src/nbproject/project.xml
+nbproject/private/private.xml

--- a/src/scripts/loqui/connectors/coseme.js
+++ b/src/scripts/loqui/connectors/coseme.js
@@ -415,6 +415,7 @@ App.connectors.coseme = function (account) {
         }
       }
 
+      onMessage("ERROR DECRYPTING MESSAGE FROM " + msg.remoteJid);
       callback(e);
     }
 


### PR DESCRIPTION
in the chat where the error occurs. this will help to regocnize any errors without reading the logs.
