### PR TITLE
stop infinite recursion in group search

### DIFF
--- a/src/scripts/loqui/connectors/xmpp.js
+++ b/src/scripts/loqui/connectors/xmpp.js
@@ -307,8 +307,12 @@ App.connectors.XMPP = function (account) {
 
   this.muc.explore = function (server, resolve, reject) {
     var disco = this.connection.disco;
+    var jidok = [];
     var process = function (s) {
       if (typeof s == 'string') {
+        var r=jidok.findIndex(function (x) { return (x==s); });
+        if (r>-1) { return; }
+        jidok.push(s);
         disco.items(s, null, process, reject);
       } else {
         s = $(s);
@@ -324,6 +328,8 @@ App.connectors.XMPP = function (account) {
             if (jid.indexOf('@') > -1) {
               resolve(jid, item.attr('name'));
             } else {
+              var r=jidok.findIndex(function (x) { return (x==jid); });
+              if (r>-1) { return; }
               disco.info(jid, null, process, reject);
             }
           });


### PR DESCRIPTION
along the search, sone tokens appear as their own item so falling in a infinite loop. So I created a array that keep track the items already done.

For example for server "jabber.univ-lille2.fr", I get 13 items and 8 times "jabber.univ-lille2.fr" :  

`
<query xmlns='http://jabber.org/protocol/disco#items'><item jid='conference.jabber.univ-lille2.fr'/><item jid='proxy.jabber.univ-lille2.fr'/><item jid='pubsub.jabber.univ-lille2.fr'/><item jid='vjud.jabber.univ-lille2.fr'/><item jid='webpresence.jabber.univ-lille2.fr'/><item jid='jabber.univ-lille2.fr' node='announce' name='Annonces'/><item jid='jabber.univ-lille2.fr' name='Configuration' node='config'/><item jid='jabber.univ-lille2.fr' name='Gestion des utilisateurs' node='user'/><item jid='jabber.univ-lille2.fr' name='Utilisateurs en ligne' node='online users'/><item jid='jabber.univ-lille2.fr' name='Tous les utilisateurs' node='all users'/><item jid='jabber.univ-lille2.fr' name='Connexions s2s sortantes' node='outgoing s2s'/><item jid='jabber.univ-lille2.fr' name='Noeuds actifs' node='running nodes'/><item jid='jabber.univ-lille2.fr' name='Noeuds arrÃªtÃ©s' node='stopped nodes'/></query>
`
