### PR TITLE
fix: In Ubuntu Touch the os name is "PC"

### DIFF
--- a/src/scripts/loqui/app.js
+++ b/src/scripts/loqui/app.js
@@ -225,7 +225,7 @@ var App = {
     Account: {
       core: {
         enabled: true,
-        resource: 'Loqui' + '-' + (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'PC'),
+        resource: 'Loqui' + '-' + (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'Ubuntu'),
         OTR: {
           enabled: false,
           key: null,


### PR DESCRIPTION
But should be "Ubuntu". Not "Ubuntu Touch" because Ubuntu Touch and Ubuntu Desktop apps
are the same (think about the unity8 session in ubuntu 16.10 and what more in the next release)