### PR TITLE
fix: In Ubuntu os name should be "Ubuntu", not "PC"

### DIFF
--- a/src/scripts/loqui/app.js
+++ b/src/scripts/loqui/app.js
@@ -392,7 +392,7 @@ var App = {
   init: function () {
     App.defaults.Connector.presence.status = _('DefaultStatus', {
       app: App.name,
-      platform: (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'PC')
+      platform: (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'Ubuntu')
     });
 
     App.defaults.Selects.language[0] = { caption : _('Default'), value : 'default' };

--- a/src/scripts/loqui/app.js
+++ b/src/scripts/loqui/app.js
@@ -225,7 +225,7 @@ var App = {
     Account: {
       core: {
         enabled: true,
-        resource: 'Loqui' + '-' + (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'PC'),
+        resource: 'Loqui' + '-' + (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'Ubuntu'),
         OTR: {
           enabled: false,
           key: null,


### PR DESCRIPTION
I was thinking between "Ubuntu" an "Ubuntu Touch", but i think simply "Ubuntu" is better because in the plan of Canonical ubuntu desktop and touch will be the same, and touch app will work on desktop and viceversa.