### PR TITLE
changed-top-bar-UTruntimeapi

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,11 +22,6 @@
     <link rel="shortcut icon" href="img/icon-32.png" type="image/png" />
 </head>
 <body class="app" data-online="false">
-	<div>
-      Results:
-      <div id="results">
-      </div>
-    </div>
   <input type="file" class="ubuntu-touch-content-hub-input" id="contacts_input" accept="text/vcard" multiple/>
   <section id="welcome" class="show" data-transition="horizontal">
     <article id="main" class="scroll show">

--- a/src/l10n/de.ini
+++ b/src/l10n/de.ini
@@ -183,7 +183,7 @@ Actioninvite=Einladen
 
 # SHOWS=
 showchat=Gesprächig
-showa=Verfügbar
+showa=Online
 showaway=Abwesend
 showxa=Längere Abwesenheit
 showdnd=Bitte nicht stören
@@ -204,6 +204,7 @@ Settings=Einstellungen
 Setreconnect=Automatisch wiederverbinden
 SetdisHide=Verstecke nicht verfügbare Kontakte
 Setsound=Ton aktivieren
+Setshowstat=Statusnachricht oben zeigen
 SetboltGet=Bolt empfangen
 Setcsn="schreibt..." Benachrichtigung
 Setpsychic=Psychic-Modus

--- a/src/l10n/en.ini
+++ b/src/l10n/en.ini
@@ -203,6 +203,7 @@ Settings=Settings
 Setreconnect=Autoreconnect
 SetdisHide=Hide not available contacts
 Setsound=Sound enabled
+Setshowstat=Show status message on top
 SetboltGet=Bolt receiving
 Setcsn=Typing notifications
 Setpsychic=Psychic mode

--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -552,14 +552,14 @@ var Account = {
 
           var show =_('show' + (contact.presence.show || 'na'));
           var time = (contact.presence.show != 'a') && contact.presence.last && Tools.convenientDate(Tools.localize(Tools.stamp(contact.presence.last)));
-          var prefix = time
+		  var prefix = time
             ? _('LastTime', {time: _('DateTimeFormat', {date: time[0], time: time[1]})})
             : show;
 
-          var status = ((contact.presence.status || time) ? (prefix + ' - ') : '') +
-            (contact.presence.status
+          var status = ((time || show == _('showa')) ? prefix : '') + ((contact.presence.status && (time || show == _('showa')) && App.settings.showstat == true) ? (' - ') : '') +
+            ((contact.presence.status && App.settings.showstat == true)
              ? App.emoji[Providers.data[this.core.provider].emoji].fy(Tools.HTMLescape(contact.presence.status))
-             : show);
+             : '');
           header.find('.status').html(status);
         }
       } else {

--- a/src/scripts/loqui/app.js
+++ b/src/scripts/loqui/app.js
@@ -11,70 +11,59 @@
 
 'use strict';
 
-/* if(typeof MozActivity == 'undefined') {
-	window.onload = function() {
-		var trigger = 0;
-		var userSoundSet;
-		
-		function setResult(message) {
-			var results = document.getElementById('results');
-			results.innerHTML += message + '<br>';
-		}
-			
-		function reconnectApp() {
-			App.settings.sound = false;
-			App.disconnect();
-			App.connect();
-			window.setTimeout(delaySound, 5000);
-			console.log('Reconnected App.');
-			
-			function delaySound() {
-				App.settings.sound = userSoundSet;
-			}
-		}
-		
-		var exec;
-		
-		var lastActive;
-		var nowActive;
-	
-	var api = external.getUnityObject('1.0');
-
-	api.RuntimeApi.getApplication(function(application) {
-		setResult('application name: ' + application.getApplicationName());
-		setResult('application info: ' + JSON.stringify(application.getPlatformInfo()));
-		
-		application.onDeactivated(function() {
-			setResult('Event: application deactivated');
-			console.log('Event: application deactivated');
-			if(trigger == 0 || userSoundSet != App.settings.sound) {
-				userSoundSet = App.settings.sound;
-				trigger = 1;
-			}
-			App.settings.sound = userSoundSet;
-			lastActive = (new Date()).getTime();
-			exec = window.setInterval(reconnectApp, 600000);
-		});
-
-		application.onActivated(function() {
-			setResult('Event: application activated');
-			console.log('Event: application activated');
-			App.settings.sound = userSoundSet;
-			clearInterval(exec);
-			nowActive = (new Date()).getTime();
-			if((nowActive - lastActive) > 100000) {
-				reconnectApp();
-			}
-		});
-		
-		});
-	};
-} */
-
 /**
  * @namespace App
  */
 var App = {
+
+runtimeApi : function() {	//Ubuntu Touch
+	var trigger = 0;
+	var userSoundSet;
+	
+	function reconnectApp() {
+		App.settings.sound = false;
+		App.disconnect();
+		App.connect();
+		window.setTimeout(delaySound, 5000);
+		console.log('Reconnected App.');
+		
+		function delaySound() {
+			App.settings.sound = userSoundSet;
+		}
+	}
+	
+	var exec;
+	
+	var lastActive;
+	var nowActive;
+
+var api = external.getUnityObject('1.0');
+
+api.RuntimeApi.getApplication(function(application) {
+	
+	application.onDeactivated(function() {
+		console.log('Event: application deactivated');
+		if(trigger == 0 || userSoundSet != App.settings.sound) {
+			userSoundSet = App.settings.sound;
+			trigger = 1;
+		}
+		App.settings.sound = userSoundSet;
+		lastActive = (new Date()).getTime();
+		exec = window.setInterval(reconnectApp, 600000);
+	});
+
+	application.onActivated(function() {
+		console.log('Event: application activated');
+		App.settings.sound = userSoundSet;
+		clearInterval(exec);
+		nowActive = (new Date()).getTime();
+		if((nowActive - lastActive) > 100000) {
+			reconnectApp();
+		}
+	});
+	
+	});
+},
 
   /**
   * @type {string}
@@ -230,6 +219,7 @@ var App = {
       settings: {
         reconnect: true,
         sound: true,
+		showstat: true,
         csn: true,
         boltGet: true,
         readReceipts: true,
@@ -450,6 +440,9 @@ var App = {
   },
 
   init: function () {
+	if(typeof MozActivity == 'undefined') {
+		App.runtimeApi();
+	}
     App.defaults.Connector.presence.status = _('DefaultStatus', {
       app: App.name,
       platform: (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'PC')

--- a/src/scripts/loqui/tools.js
+++ b/src/scripts/loqui/tools.js
@@ -41,16 +41,13 @@ var Tools = {
   convenientDate: function (stamp) {
     var day = this.day(stamp);
     var today = this.day(this.localize(this.stamp()));
-	var yesterday = new Date(new Date().setDate(new Date().getDate()-1));
-	var yestString = yesterday.toISOString();
-	var yestStringConv = yestString.replace(/-/g, ',').split('T')[0];
-	console.log(day + '     ' + yestStringConv);
+	var yesterday = this.day(this.localize(this.stamp(((new Date().getTime()) / 1000) - 86400)));
     var dayString =
       day.toString() == today.toString()
       ?
         _('Today')
       :
-	  day == yestStringConv
+	  day.toString() == yesterday.toString()
 	  ?
 	   _('Yesterday')
 	  :

--- a/src/scripts/loqui/tools.js
+++ b/src/scripts/loqui/tools.js
@@ -41,11 +41,19 @@ var Tools = {
   convenientDate: function (stamp) {
     var day = this.day(stamp);
     var today = this.day(this.localize(this.stamp()));
+	var yesterday = new Date(new Date().setDate(new Date().getDate()-1));
+	var yestString = yesterday.toISOString();
+	var yestStringConv = yestString.replace(/-/g, ',').split('T')[0];
+	console.log(day + '     ' + yestStringConv);
     var dayString =
       day.toString() == today.toString()
       ?
         _('Today')
       :
+	  day == yestStringConv
+	  ?
+	   _('Yesterday')
+	  :
         _('DateFormat', {day: day[2], month: day[1]})
     ;
     return [


### PR DESCRIPTION
- Add option to the settings to enable/disable the status message in the
top bar
- Display 'Yesterday' instead of the date
- Display nothing when a contact doesn't share his lastonline state
(except when online)
- Display ' - ' only when both lastonline and status message are
available
- Translation additions/changes (de and en)
- Put UT's runtimeApi elsewhere (init instead of window.onload)