### PR TITLE
fix-for-FFOS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -135,7 +135,7 @@
     <article id="info" class="simple scroll">
       <h1><span data-var="name"></span> <span data-var="version"></span><span data-var="minorVersion"></span></h1>
       <p><a target="_external" href="https://github.com/loqui/im/releases"><em data-l10n-id="Changelog">Changelog</em></a></p>
-      <p data-l10n-id="Copyright">Â© 2013-2014 Loqui IM. Some rights reserved.</p>
+      <p data-l10n-id="Copyright">© 2013-2014 Loqui IM. Some rights reserved.</p>
       <p><a target="_external" href="http://loqui.im/"><em data-l10n-id="Website">Website</em></a></p>
       <p><a target="_external" href="https://github.com/loqui/im/issues?state=open"><em data-l10n-id="ReportIssue">Report an issue</em></a></p><br />
       <p><small data-l10n-id="FreeSoftware">This program is free software; you may redistribute and/or modify it under the terms of the GNU Affero General Public License (AGPL 3) as published by the Free Software Foundation.</small></p>
@@ -150,8 +150,8 @@
     <article id="main" class="scroll">
       <div id="card">
       	<!-- background_input is displayed outside the window, the click on this element is triggered
-      		and for security reason it could not be hidden -->
-      	<input type="file" class="ubuntu-touch-content-hub-input" id="background_input" accept="image/*" />
+             and for security reason it could not be hidden -->
+        <input type="file" class="ubuntu-touch-content-hub-input" id="background_input" accept="image/*" />
         <span class="avatar"><img/></span>
         <span class="name"></span>
         <span class="user"></span>
@@ -186,8 +186,8 @@
     <article id="main" class="scroll">
       <div id="card">
       	<!-- avatar_input is displayed outside the window, the click on this element is triggered
-      		and for security reason it could not be hidden -->
-      	<input type="file" class="ubuntu-touch-content-hub-input" id="avatar_input" accept="image/*" />
+             and for security reason it could not be hidden -->
+        <input type="file" class="ubuntu-touch-content-hub-input" id="avatar_input" accept="image/*" />
         <span class="avatar"><img/></span>
         <span class="name"></span>
         <span class="user"></span>
@@ -399,7 +399,7 @@
       </header>
       <article class="scroll">
           <ul class="itemList">
-          	<input type="file" class="ubuntu-touch-content-hub-input" id="filesend_input" accept="" />
+          	<!-- <input type="file" class="ubuntu-touch-content-hub-input" id="filesend_input" accept="" /> -->
             <li class="file" data-menu-onclick="fileSend">
               <i class="material-icons">insert_drive_file</i>
               <span  data-l10n-id="MediaType_file">File</span>
@@ -408,7 +408,7 @@
               <i class="material-icons">place</i>
               <span data-l10n-id="MediaType_url">Location</span>
             </li>
-            <input type="file" class="ubuntu-touch-content-hub-input" id="vcardsend_input" accept="text/vcard" />
+            <!-- <input type="file" class="ubuntu-touch-content-hub-input" id="vcardsend_input" accept="text/vcard" /> -->
             <li class="vcard" data-menu-onclick="vcardSend">
               <i class="material-icons">contact_phone</i>
               <span data-l10n-id="MediaType_vCard">Contact</span>

--- a/src/scripts/loqui/account.js
+++ b/src/scripts/loqui/account.js
@@ -452,9 +452,10 @@ var Account = {
     var frag = f;
     account = this;
     this.contacts = {};
-    if(this.core.roster == undefined && external && external.getUnityObject){
-    	this.core.roster = [];
+    if(this.core.roster == undefined && App.platform === "UbuntuTouch") {
+      this.core.roster = [];
     }
+
     this.core.roster.forEach(function (contact, i, roster) {
       var name = contact.name || contact.jid;
       var nameParts = name.toLowerCase().split(' ');
@@ -555,14 +556,15 @@ var Account = {
 
           var show =_('show' + (contact.presence.show || 'na'));
           var time = (contact.presence.show != 'a') && contact.presence.last && Tools.convenientDate(Tools.localize(Tools.stamp(contact.presence.last)));
-		  var prefix = time
+          var prefix = time
             ? _('LastTime', {time: _('DateTimeFormat', {date: time[0], time: time[1]})})
             : show;
 
-          var status = ((time || show == _('showa')) ? prefix : '') + ((contact.presence.status && (time || show == _('showa')) && App.settings.showstat == true) ? (' - ') : '') +
-            ((contact.presence.status && App.settings.showstat == true)
-             ? App.emoji[Providers.data[this.core.provider].emoji].fy(Tools.HTMLescape(contact.presence.status))
-             : '');
+          var status = ( (time || show == _('showa')) ? prefix : '' ) +
+            ( (contact.presence.status && (time || show == _('showa')) && App.settings.showstat == true) ? (' - ') : '' ) +
+            ( (contact.presence.status && App.settings.showstat == true)
+                ? App.emoji[Providers.data[this.core.provider].emoji].fy(Tools.HTMLescape(contact.presence.status))
+                  : '' );
           header.find('.status').html(status);
         }
       } else {

--- a/src/scripts/loqui/app.js
+++ b/src/scripts/loqui/app.js
@@ -15,56 +15,6 @@
  * @namespace App
  */
 var App = {
-
-runtimeApi : function() {	//Ubuntu Touch
-	var trigger = 0;
-	var userSoundSet;
-	
-	function reconnectApp() {
-		App.settings.sound = false;
-		App.disconnect();
-		App.connect();
-		window.setTimeout(delaySound, 1500);
-		console.log('Reconnected App.');
-		
-		function delaySound() {
-			App.settings.sound = userSoundSet;
-		}
-	}
-	
-	var exec;
-	
-	var lastActive;
-	var nowActive;
-
-var api = external.getUnityObject('1.0');
-
-api.RuntimeApi.getApplication(function(application) {
-	
-	application.onDeactivated(function() {
-		console.log('Event: application deactivated');
-		if(trigger == 0 || userSoundSet != App.settings.sound) {
-			userSoundSet = App.settings.sound;
-			trigger = 1;
-		}
-		App.settings.sound = userSoundSet;
-		lastActive = (new Date()).getTime();
-		exec = window.setInterval(reconnectApp, 600000);
-	});
-
-	application.onActivated(function() {
-		console.log('Event: application activated');
-		App.settings.sound = userSoundSet;
-		clearInterval(exec);
-		nowActive = (new Date()).getTime();
-		if((nowActive - lastActive) > 100000) {
-			reconnectApp();
-		}
-	});
-	
-	});
-},
-
   /**
   * @type {string}
   * @const
@@ -88,6 +38,8 @@ api.RuntimeApi.getApplication(function(application) {
   * @const
   */
   minorVersion: 'a',
+
+  platform: '',
 
   /**
   * @type {Connector[]}
@@ -219,7 +171,7 @@ api.RuntimeApi.getApplication(function(application) {
       settings: {
         reconnect: true,
         sound: true,
-		showstat: true,
+        showstat: true,
         csn: true,
         boltGet: true,
         readReceipts: true,
@@ -440,9 +392,11 @@ api.RuntimeApi.getApplication(function(application) {
   },
 
   init: function () {
-	if(typeof MozActivity == 'undefined') {
-		App.runtimeApi();
-	}
+    App.platform = Lungo.Core.environment().os.name;
+
+    if (App.platform === "UbuntuTouch") {
+      App.runtimeApi();
+	  }
     App.defaults.Connector.presence.status = _('DefaultStatus', {
       app: App.name,
       platform: (Lungo.Core.environment().os ? Lungo.Core.environment().os.name : 'PC')
@@ -618,17 +572,17 @@ api.RuntimeApi.getApplication(function(application) {
   * @param {string} last
   */
   start: function (last) {
-	if(typeof MozActivity != 'undefined') {
-	emojione.sprites = false;
-	}
-	else {
-	emojione.sprites = true;
-	}
+      if(App.platform === "FirefoxOS") {
+		    emojione.sprites = false;
+		}
+		else {
+			emojione.sprites = true;
+		}
+
     App.online = App.online;
     emojione.imagePathPNG = '/img/emoji/emojione/';
     // If there is already a configured account
     if (App.accounts.length) {
-
       screen.unlockOrientation= screen.unlockOrientation || screen.mozUnlockOrientation;
       if(!App.settings.lockOrientation && screen.unlockOrientation){
         screen.unlockOrientation();
@@ -652,6 +606,10 @@ api.RuntimeApi.getApplication(function(application) {
     } else {
       // Show wizard
       Menu.show('providers', null, 500);
+    }
+
+    if (App.platform !== "UbuntuTouch") {
+      $('[class^="ubuntu-touch-"]').remove();
     }
   },
 
@@ -1103,6 +1061,50 @@ api.RuntimeApi.getApplication(function(application) {
       Lungo.Router.section('back');
       callback($('section#backupPassword input')[0].value);
     };
-  }
+  },
 
+	runtimeApi : function() {	//Ubuntu Touch
+    var trigger = 0;
+  	var userSoundSet;
+
+  	function reconnectApp() {
+      App.settings.sound = false;
+      App.disconnect();
+      App.connect();
+      window.setTimeout(delaySound, 1500);
+      console.log('Reconnected App.');
+
+  		function delaySound() {
+  			App.settings.sound = userSoundSet;
+  		}
+  	}
+
+  	var exec;
+    var lastActive;
+  	var nowActive;
+  	var api = external.getUnityObject('1.0');
+
+    api.RuntimeApi.getApplication(function(application) {
+  	  application.onDeactivated(function() {
+  		  console.log('Event: application deactivated');
+  		  if(trigger == 0 || userSoundSet != App.settings.sound) {
+  			  userSoundSet = App.settings.sound;
+  			  trigger = 1;
+  		  }
+  		  App.settings.sound = userSoundSet;
+  		  lastActive = (new Date()).getTime();
+  		  exec = window.setInterval(reconnectApp, 600000);
+  	  });
+
+  	  application.onActivated(function() {
+  		  console.log('Event: application activated');
+  		  App.settings.sound = userSoundSet;
+  		  clearInterval(exec);
+  		  nowActive = (new Date()).getTime();
+  		  if((nowActive - lastActive) > 100000) {
+  			  reconnectApp();
+  		  }
+      });
+    });
+  }
 };

--- a/src/scripts/loqui/bindings.js
+++ b/src/scripts/loqui/bindings.js
@@ -83,7 +83,7 @@ document.addEventListener("visibilitychange", function() {
   });
 });
 
-//Avatar handling for non FirefoxOS
+// Avatar handling for non FirefoxOS
 $('#avatar_input').change(function() {
     var image = document.getElementById('avatar_input').files[0];
     Messenger.avatarSet(image);
@@ -105,60 +105,59 @@ $('section#me #card span.avatar').on('click', function (e) {
       Messenger.avatarSet(image.blob);
     };
     pick.onerror = function(){};
-  } else if(external && external.getUnityObject) {
+  } else if (App.platform === "UbuntuTouch") {
 	  //Ubuntu Touch: open contentHub
-	  $('#avatar_input').trigger('click'); 
+	  $('#avatar_input').trigger('click');
   } else {
     Lungo.Notification.error(_('NoDevice'), _('FxOSisBetter', 'exclamation-sign'));
   }
 });
 
 // Tap contact or muc avatar
-var listener= function(muc){
+var listener= function(muc) {
   var jid= muc ? $('section#muc')[0].dataset.jid : $('section#contact')[0].dataset.jid;
   var avatar= App.avatars[jid];
 
-  if(avatar){
-    Store.recover((avatar.original || avatar.chunk), function(key, url, free){
+  if(avatar) {
+    Store.recover((avatar.original || avatar.chunk), function(key, url, free) {
       var blob = Tools.b64ToBlob(url.split(',').pop(), url.split(/[:;]/)[1]);
-      if (typeof MozActivity != 'undefined') {
-            	//FirefoxOS
-				return new MozActivity({
-				  name: 'open',
-				  data: {
-					type: blob.type,
-					blob: blob
-				  }
-				});
-			} else if(external && external.getUnityObject) {
-            	//Ubuntu Touch
-				var h = $(window).height();
-				var w = $(window).width();
-				var img = document.createElement('img');
-				var prop = new Image();
-				prop.src = url;
-				var propHeight = prop.height;
-				var propWidth = prop.width;
-				img.setAttribute('src', url);
-				if(propWidth/propHeight > w/h) {
-					img.setAttribute('width', w);
-				} else {
-					img.setAttribute('height', h);
-				}
-				if(muc) {
-					var group = document.getElementById('muc');
-					group.appendChild(img);
-					group.addEventListener('click', function () {
-						group.removeChild(img);
-					});
-				} else {
-					var contact = document.getElementById('contact');
-					contact.appendChild(img);
-					contact.addEventListener('click', function () {
-						contact.removeChild(img);
-					});
-				}
-            }
+
+      if (App.platform === "FirefoxOS") {
+  			return new MozActivity({
+  				name: 'open',
+  				data: {
+  					type: blob.type,
+  					blob: blob
+  				}
+  			});
+  		} else if (App.platform === "UbuntuTouch") {
+  			var h = $(window).height();
+  			var w = $(window).width();
+  			var img = document.createElement('img');
+  			var prop = new Image();
+  			prop.src = url;
+  			var propHeight = prop.height;
+  			var propWidth = prop.width;
+  			img.setAttribute('src', url);
+  			if (propWidth/propHeight > w/h) {
+  				img.setAttribute('width', w);
+  			} else {
+  				img.setAttribute('height', h);
+  			}
+  			if (muc) {
+  				var group = document.getElementById('muc');
+  				group.appendChild(img);
+  				group.addEventListener('click', function () {
+  					group.removeChild(img);
+  				});
+  			} else {
+  				var contact = document.getElementById('contact');
+  				contact.appendChild(img);
+  				contact.addEventListener('click', function () {
+  				  contact.removeChild(img);
+  			  });
+  			}
+      }
 
       free();
     });
@@ -226,7 +225,7 @@ $('section#me #card button.background.change').on('click', function (e) {
     e.onerror = function () {
       Tools.log('Picture selection was canceled');
     };
-  } else if(external && external.getUnityObject) {
+  } else if(App.platform === "UbuntuTouch") {
 	  //Ubuntu Touch: open contentHub
 	  $('#background_input').trigger('click');
   } else {
@@ -297,7 +296,7 @@ var bindings = function () {
   $('section#welcome').on('click', function() {
     Menu.show('providers');
   });
-  
+
   $('section#chat').on('swipeRight', function() {
     Lungo.Router.section('back');
   });
@@ -366,7 +365,7 @@ var bindings = function () {
       }
     }
   });
-  
+
   window.addEventListener('touchend', function() {
     VoiceRecorder.stop(duration => {
       if (duration < 1) {

--- a/src/scripts/loqui/message.js
+++ b/src/scripts/loqui/message.js
@@ -336,9 +336,9 @@ var Message = {
   preRender : function (avatarize) {
     var message = this;
     var account = this.account;
-    var html= null;
+    var html = null;
 	  var htmlUT = null;
-    var onDivClick= null;
+    var onDivClick = null;
     if (this.core.text) {
       html = App.emoji[Providers.data[this.account.core.provider].emoji].fy(Tools.urlHL(Tools.HTMLescape(this.core.text)));
       html = html.replace(/(\*)([A-Za-z0-9\s]+)(\*)/g, '<b>$2</b>');
@@ -348,150 +348,146 @@ var Message = {
       html = $('<img/>').attr('src', this.core.media.thumb);
       html[0].dataset.downloaded = this.core.media.downloaded || false;
       switch (this.core.media.type) {
-        case 'url':
-		html.addClass('maps');
-		console.log('Map Received: ' + message.core.media.url);
-		if(external && external.getUnityObject) {
-			//Ubuntu Touch
-			htmlUT = $('<a></a>').attr('href', message.core.media.url);
-			htmlUT.append(html);
-			html = htmlUT;
-		} else {
-			var onClick = function(e){
-				e.preventDefault();
-				//FirefoxOS
-				return new MozActivity({
-				  name: "view",
-				  data: {
-					type: "url",
-					url: message.core.media.url
-				  }
-				});
-			  };
-		  }
-          break;
-        case 'vCard':
-          onClick = function(e){
+      case 'url':
+		    html.addClass('maps');
+		    if (App.platform === "UbuntuTouch") {
+			    htmlUT = $('<a></a>').attr('href', message.core.media.url);
+			    htmlUT.append(html);
+			    html = htmlUT;
+		    } else {
+          var onClick = function(e) {
             e.preventDefault();
-            if (typeof MozActivity != 'undefined') {
-            	//FirefoxOS
-				return new MozActivity({
-				  name: 'open',
-				  data: {
-					type: 'text/vcard',
-					blob: new Blob([ message.core.media.payload[1] ],
-								   { type : 'text/vcard' })
-				  }
-				});
-			} else if(external && external.getUnityObject) {
-            	//Ubuntu Touch
-
-            }
+            return new MozActivity({
+              name: "view",
+              data: {
+                type: "url",
+                url: message.core.media.url
+              }
+            });
           };
-          break;
+        }
+        break;
+
+      case 'vCard':
+        onClick = function(e) {
+          e.preventDefault();
+          if (App.platform === "FirefoxOS") {
+            return new MozActivity({
+              name: 'open',
+              data: {
+                type: 'text/vcard',
+                blob: new Blob([ message.core.media.payload[1] ], { type : 'text/vcard' })
+              }
+            });
+          } else if(App.platform === "UbuntuTouch") {
+            console.log("UT");
+          }
+        };
+        break;
 
         default:
           html.addClass(this.core.media.type);
           var open = function (blob) {
-            if (typeof MozActivity != 'undefined') {
-            	//FirefoxOS
-				return new MozActivity({
-				  name: 'open',
-				  data: {
-					type: blob.type,
-					blob: blob
-				  }
-				});
-			} else if(external && external.getUnityObject) {
-            	//Ubuntu Touch
-				Tools.blobToBase64(blob, function (output) {
-					if(output) {
-						var type = output.split('/')[0];
-						var h = $(window).height();
-						var w = $(window).width();
-						var chat = document.getElementById('chat');
-						if(type == 'data:image') {
-							var img = document.createElement('img');
-							var prop = new Image();
-							prop.src = output;
-							var propHeight = prop.height;
-							var propWidth = prop.width;
-							img.setAttribute('src', output);
-							if(propWidth/propHeight > w/h) {
-								img.setAttribute('width', w);
-							} else {
-								img.setAttribute('height', h);
-							}
-							chat.appendChild(img);
-							chat.addEventListener('click', function () {
-								chat.removeChild(img);
-							});
-						} else if(type == 'data:audio') {
-							var img = document.createElement('img');
-							img.setAttribute('src', "img/play.png");
-							var close = document.createElement('img');
-							close.setAttribute('src', "img/console-inactive.png");
-							var audio = document.createElement('audio');
-							audio.setAttribute("src", output);
-							chat.appendChild(img);
-							chat.appendChild(close);
-							chat.appendChild(audio);
-							close.addEventListener('click', function () {
-								audio.setAttribute("src", "");
-								audio.load();
-								chat.removeChild(audio);
-								chat.removeChild(img);
-								chat.removeChild(close);
-							});
-							img.addEventListener('click', function () {
-								if (audio.paused == false) {
-									img.setAttribute('src', "img/play.png");
-									chat.replaceChild(img, img);
-									audio.pause();
-									audio.firstChild.nodeValue = 'Play';
-								} else {
-									img.setAttribute('src', "img/audio.png");
-									chat.replaceChild(img, img);
-									audio.play();
-									audio.firstChild.nodeValue = 'Pause';
-								}
-							});
-						} else if(type == 'data:video') {
-							var close = document.createElement('img');
-							close.setAttribute('src', "img/console-inactive.png");
-							function addSourceToVideo(element, src, type) {
-								var source = document.createElement('source');
-								source.src = src;
-								source.type = type;
-								element.appendChild(source);
-							}
-							var video = document.createElement('video');
-							chat.appendChild(close);
-							chat.appendChild(video);		
-							addSourceToVideo(video, output, blob.type);
-							var propHeight = video.videoHeight;
-							var propWidth = video.videoWidth;
-							if(propWidth/propHeight > w/h) {
-								video.setAttribute('width', w);
-							} else {
-								video.setAttribute('height', h);
-							}
-							close.addEventListener('click', function () {
-								chat.removeChild(video);
-								chat.removeChild(close);
-							});
-							video.addEventListener('click', function () {
-								if (video.paused == false) {
-									video.pause();
-									video.firstChild.nodeValue = 'Play';
-								} else {
-									video.play();
-									video.firstChild.nodeValue = 'Pause';
-								}
-							});
-						}
-					}
-				});
+            if (App.platform === "FirefoxOS") {
+              return new MozActivity({
+      				  name: 'open',
+      				  data: {
+        					type: blob.type,
+        					blob: blob
+      				  }
+      				});
+			      } else if (App.platform === "UbuntuTouch") {
+              /*
+              Tools.blobToBase64(blob, function (output) {
+                if(output) {
+                  var type = output.split('/')[0];
+                  var h = $(window).height();
+                  var w = $(window).width();
+                  var chat = document.getElementById('chat');
+                  // This is not what you whant! The chat itself is
+                  // section#chat article#main ul#messages li:lastChild
+                  if (type == 'data:image') {
+                    var img = document.createElement('img');
+                    var prop = new Image();
+                    prop.src = output;
+                    var propHeight = prop.height;
+                    var propWidth = prop.width;
+                    img.setAttribute('src', output);
+                    if (propWidth/propHeight > w/h) {
+                      img.setAttribute('width', w);
+                    } else {
+                      img.setAttribute('height', h);
+                    }
+                    chat.appendChild(img);
+                    chat.addEventListener('click', function () {
+                      chat.removeChild(img);
+                    });
+                  } else if(type == 'data:audio') {
+                    var img = document.createElement('img');
+                    img.setAttribute('src', "img/play.png");
+                    var close = document.createElement('img');
+                    close.setAttribute('src', "img/console-inactive.png");
+                    var audio = document.createElement('audio');
+                    audio.setAttribute("src", output);
+                    chat.appendChild(img);
+                    chat.appendChild(close);
+                    chat.appendChild(audio);
+                    close.addEventListener('click', function () {
+                      audio.setAttribute("src", "");
+                      audio.load();
+                      chat.removeChild(audio);
+                      chat.removeChild(img);
+                      chat.removeChild(close);
+                    });
+                    img.addEventListener('click', function () {
+                      if (audio.paused == false) {
+                        img.setAttribute('src', "img/play.png");
+                        chat.replaceChild(img, img);
+                        audio.pause();
+                        audio.firstChild.nodeValue = 'Play';
+                      } else {
+                        img.setAttribute('src', "img/audio.png");
+                        chat.replaceChild(img, img);
+                        audio.play();
+                        audio.firstChild.nodeValue = 'Pause';
+                      }
+                    });
+                  } else if(type == 'data:video') {
+                    var close = document.createElement('img');
+                    close.setAttribute('src', "img/console-inactive.png");
+                    function addSourceToVideo(element, src, type) {
+                      var source = document.createElement('source');
+                      source.src = src;
+                      source.type = type;
+                      element.appendChild(source);
+                    }
+                    var video = document.createElement('video');
+                    chat.appendChild(close);
+                    chat.appendChild(video);
+                    addSourceToVideo(video, output, blob.type);
+                    var propHeight = video.videoHeight;
+                    var propWidth = video.videoWidth;
+                    if(propWidth/propHeight > w/h) {
+                      video.setAttribute('width', w);
+                    } else {
+                      video.setAttribute('height', h);
+                    }
+                    close.addEventListener('click', function () {
+                      chat.removeChild(video);
+                      chat.removeChild(close);
+                    });
+                    video.addEventListener('click', function () {
+                      if (video.paused == false) {
+                        video.pause();
+                        video.firstChild.nodeValue = 'Play';
+                      } else {
+                        video.play();
+                        video.firstChild.nodeValue = 'Pause';
+                      }
+                    });
+                  }
+                }
+              }); */
             }
           };
           onClick = function (e) {
@@ -504,7 +500,7 @@ var Message = {
               ext = 'mp3';
             }
             var localUrl = App.pathFiles + $(e.target).closest('[data-stamp]')[0].dataset.stamp.replace(/[-:]/g, '') + url.split('/').pop().substring(0, 5).toUpperCase() + '.' + ext;
-            if (img.dataset.downloaded == 'true' && typeof MozActivity != 'undefined') {
+            if (img.dataset.downloaded == 'true' && App.platform === "FirefoxOS") {
               Store.SD.recover(localUrl, function (blob) {
                 open(blob);
               });
@@ -556,18 +552,18 @@ var Message = {
           };
           break;
       }
-	if(!(external && external.getUnityObject) || this.core.media.type != 'url') {
-	      html.bind('click', onClick);
-	      onDivClick = function(e) {
-		e.preventDefault();
-		var target = $(e.target);
-		var span = target[0].lastChild;
-		if (span) {
-		  var img = span.firstChild;
-		  img.click();
-		}
-	      };
-	}
+      if (App.platform === "UbuntuTouch" || this.core.media.type != 'url') {
+        html.bind('click', onClick);
+        onDivClick = function(e) {
+          e.preventDefault();
+          var target = $(e.target);
+          var span = target[0].lastChild;
+          if (span) {
+            var img = span.firstChild;
+            img.click();
+          }
+        };
+      }
     }
     var type = (this.core.from == this.account.core.user || this.core.from == this.account.core.realJid) ? 'out' : 'in';
     var contact = Lungo.Core.findByProperty(this.account.core.roster, 'jid', Strophe.getBareJidFromJid(this.core.from));

--- a/src/scripts/loqui/tools.js
+++ b/src/scripts/loqui/tools.js
@@ -41,18 +41,14 @@ var Tools = {
   convenientDate: function (stamp) {
     var day = this.day(stamp);
     var today = this.day(this.localize(this.stamp()));
-	var yesterday = this.day(this.localize(this.stamp(((new Date().getTime()) / 1000) - 86400)));
+    var yesterday = this.day(this.localize(this.stamp(((new Date().getTime()) / 1000) - 86400)));
     var dayString =
-      day.toString() == today.toString()
-      ?
-        _('Today')
-      :
-	  day.toString() == yesterday.toString()
-	  ?
-	   _('Yesterday')
-	  :
-        _('DateFormat', {day: day[2], month: day[1]})
-    ;
+      (day.toString() == today.toString()) ?
+        _('Today') : (
+          (day.toString() == yesterday.toString()) ?
+            _('Yesterday') :
+              _('DateFormat', {day: day[2], month: day[1]})
+        );
     return [
       dayString,
       this.hour(stamp)

--- a/src/scripts/tapquo/quo.js
+++ b/src/scripts/tapquo/quo.js
@@ -524,8 +524,9 @@
       ipad: /(iPad).*OS\s([\d_]+)/,
       iphone: /(iPhone\sOS)\s([\d_]+)/,
       Blackberry: /(BlackBerry|BB10|Playbook).*Version\/([\d.]+)/,
-      FirefoxOS: /(Mozilla).*Mobile[^\/]*\/([\d\.]*)/,
-      webOS: /(webOS|hpwOS)[\s\/]([\d.]+)/
+      FirefoxOS: /(Mozilla).*(\(Mobile)[^\/]*\/([\d\.]*)/,
+      webOS: /(webOS|hpwOS)[\s\/]([\d.]+)/,
+      UbuntuTouch: /(Mozilla).*(Ubuntu; Mobile)[^\/]*\/([\d\.]*)/
     };
     $$.isMobile = function() {
       _current = _current || _detectEnvironment();
@@ -828,7 +829,7 @@
       if (screen.addEventListener) {
         screen.addEventListener('mozorientationchange', _getSwipeMin);
       }
-      
+
       return environment.bind("touchcancel", _cleanGesture);
     };
     _onTouchStart = function(event) {

--- a/src/scripts/tapquo/quo.js
+++ b/src/scripts/tapquo/quo.js
@@ -526,7 +526,7 @@
       Blackberry: /(BlackBerry|BB10|Playbook).*Version\/([\d.]+)/,
       FirefoxOS: /(Mozilla).*(\(Mobile)[^\/]*\/([\d\.]*)/,
       webOS: /(webOS|hpwOS)[\s\/]([\d.]+)/,
-      UbuntuTouch: /(Mozilla).*(Ubuntu; Mobile)[^\/]*\/([\d\.]*)/
+      UbuntuTouch: /(WhatsApp).*Version\/([\d.]+)/
     };
     $$.isMobile = function() {
       _current = _current || _detectEnvironment();


### PR DESCRIPTION
This PR cleans up the FFOS/UT specific stuff by adding the user agent from UT to Lungo and adding App.platform FFOS/UT can now be detected by
if (App.platform === "FirefoxOS" || App.platform === "UbuntuTouch")...

Also some row are commented out in message.js (400:490) 
These break compatibility for now and there is an errror: document.getElementById('chat') is not the element to add some message content. the correct location is section#chat article#main ul#messages li:last-of-type
